### PR TITLE
Corrected benefits header size

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -116,7 +116,7 @@ header li {
    color: #ffffff;
 }
 
-.benefits h2 {
+.benefits h3 {
    margin-bottom: 10px;
    text-align: center;
 }

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
       <!-- Side content about benefits, each text block and image is an article. -->
       <section class="benefits">
          <article>
-            <h2>Lead Generation</h2>
+            <h3>Lead Generation</h3>
             <img src="./assets/images/lead-generation.png" alt=""/>
             <p>
                Inbound strategies for lead generation require less work for
@@ -89,7 +89,7 @@
             </p>
          </article>
          <article>
-            <h2>Brand Awareness</h2>
+            <h3>Brand Awareness</h3>
             <img src="./assets/images/brand-awareness.png" alt=""/>
             <p>
                Users find your business through paid and organic searches,
@@ -98,7 +98,7 @@
             </p>
          </article>
          <article>
-            <h2>Cost Management</h2>
+            <h3>Cost Management</h3>
             <img src="./assets/images/cost-management.png" alt=""/>
             <p>
                As the search ranking for your business increases, your


### PR DESCRIPTION
Benefits headers were accidently `<h2>` headers but the mock up clearly shows them smaller.  A look back at the initial commit shows that they were supposed to be `<h3>`.